### PR TITLE
Test case for inserting east-asian han characters. Seems to work fine

### DIFF
--- a/test/rad/buffer_test.clj
+++ b/test/rad/buffer_test.clj
@@ -15,6 +15,16 @@
 
          [\r \a])))
 
+  (testing "inserting Japanese character at [_ 1]"
+    (is (=
+         (insert-char-in-line
+          [\r \a]
+          ([0 1] 1)
+          \行
+          )
+         [\r \行]
+         )))
+
   (testing "inserting a character at 1x1 in the a buffer"
     (is (=
          (insert-char-in-buffer


### PR DESCRIPTION
And a small note for people interested in languages: 

行 means row (my Taiwanese friend told me, at least). It is a pictogram depicting a street intersection. In math and language, it means row. The name of this editor comes from the Swedish word 'rad', meaning 'row' (because the whole editor is just a bunch of functions for editing _rows_ of text. So the name of this editor in Chinese, Korean & Japanese is 行. Japanese would also write it as ラド (ra do), but in hangeul (Korean phonetic letters) I don't know. If you know, please tell me! Always curious to learn. 
