### PR TITLE
Insert characters at newline

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :plugins [[jonase/eastwood "0.2.1"]]
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [clojure-lanterna "0.9.4"]
                  [org.eclipse/swt-cocoa-macosx-x86_64 "3.5.2"]]
   :main rad.core)

--- a/src/rad/buffer.clj
+++ b/src/rad/buffer.clj
@@ -15,13 +15,12 @@
   [line column alphanumeric]
   (assoc line column alphanumeric))
 
-;; fixme rename to in
 (defn insert-char-in-buffer
   "Returns buffer with char inserted at point"
   [buffer point alphanumeric]
   (assoc buffer (second point) (insert-char-in-line
-                                (buffer (first point)) ;x
-                                (second point)         ;y
+                                (buffer (second point)) ;y - line
+                                (first point)           ;x - column
 
                                 alphanumeric)))
 

--- a/src/rad/buffer.clj
+++ b/src/rad/buffer.clj
@@ -16,13 +16,47 @@
   (assoc line column alphanumeric))
 
 (defn insert-char-in-buffer
-  "Returns buffer with char inserted at point"
+  "Inserts char at point in buffer.
+  If char is a \newline, it will insert a new line in the buffer after point"
   [buffer point alphanumeric]
-  (assoc buffer (second point) (insert-char-in-line
-                                (buffer (second point)) ;y - line
-                                (first point)           ;x - column
+  (condp = alphanumeric
 
-                                alphanumeric)))
+    ;; In case of \newline, a buffer like this:
+    ;; r|a ; (| means point, or [1 0])
+    ;; d!
+    ;;
+    ;; turnes into:
+    ;; r
+    ;; a
+    ;; d!
+    
+    \newline (let [point-x (first point)
+                   point-y (second point)
+                   current-line (buffer point-y)
+
+                   every-line-above-current-line (subvec buffer 0 point-y)     ;; collection of lines
+                   current-line-until-point (subvec current-line 0 point-x)    ;; one line
+                   rest-of-current-line (subvec current-line point-x)          ;; one line
+                   every-line-below-current-line (subvec buffer (+ 1 point-y)) ;; collection of lines
+
+                   ;; let's do it all in the let
+                   every-line-above-plus-current-until-point (conj every-line-above-current-line current-line-until-point)
+                   above-current-plus-rest-of-current (conj every-line-above-plus-current-until-point rest-of-current-line)
+
+                   ;; Here is the last bug. I'm adding a collection into another collection.
+                   ;; What I want to do is to add every item of every-line-below-current-line into above-current-plus-rest-of-current
+                   the-whole-pancake (into above-current-plus-rest-of-current every-line-below-current-line)
+                   ]
+
+               the-whole-pancake)
+
+    
+    ;; else
+    (assoc buffer (second point) (insert-char-in-line
+                                  (buffer (second point)) ;y - line
+                                  (first point)           ;x - column
+
+                                  alphanumeric))))
 
 (defn insert-char!
   "Inserts a character into the current buffer at point"

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -25,11 +25,17 @@
             (sync-frontend-cursor-to-point-atom!)))
 
 (defn handle-keypress!
-  "Takes a key press, and delegates it into the proper action"
+  "Takes a key press, and delegates it into the proper action
+
+  Todos: 
+  * Make it front-end agnostic - now it depends on many things from the terminal front end"
   [key] (do (println (str "keypress: " key))
-            (buffer/insert-char! @point key)
+            (if (= :enter key) ;; replace with fn frontend/normalize-key
+              (buffer/insert-char! @point \newline)
+              
+              (buffer/insert-char! @point key))
             (move-point-forward! 1)
-            (terminal/render-buffer! (deref buffer/current-buffer) terminal/scr)))
+            (terminal/render-buffer! @buffer/current-buffer terminal/scr)))
 
 (defn -main []
   (do

--- a/test/rad/buffer_test.clj
+++ b/test/rad/buffer_test.clj
@@ -15,15 +15,14 @@
 
          [\r \a])))
 
-  (testing "inserting Japanese character at [_ 1]"
+  (testing "inserting Henji character at [_ 1]"
     (is (=
          (insert-char-in-line
           [\r \a]
           ([0 1] 1)
           \行
           )
-         [\r \行]
-         )))
+         [\r \行])))
 
   (testing "inserting a character at 1x1 in the a buffer"
     (is (=
@@ -33,7 +32,15 @@
           \?)
 
          [[\r \a]
-          [\d \?]]))))
+          [\d \?]])))
+
+  (testing "inserting a character at the end of a line in a buffer"
+    (is (=
+         (insert-char-in-buffer @example-buffer [2 1] \?)
+
+         [[\r \a]
+          [\d \! \?]]
+         ))))
 
 (deftest print-buffer-tests
   (testing "printing a line"

--- a/test/rad/buffer_test.clj
+++ b/test/rad/buffer_test.clj
@@ -4,6 +4,13 @@
 
 (def example-buffer (atom [[\r \a]
                            [\d \!]]))
+(def long-example-buffer (atom [[\r \a \d]
+                                [\i \s]
+                                [\m \e \a \n \t]
+                                [\t \o]
+                                [\b \e]
+                                [\h \a \c \k \e \d]
+                                ]))
 
 (deftest inserting-into-buffers-tests
   (testing "inserting a character at 2nd position in a line"
@@ -40,7 +47,27 @@
 
          [[\r \a]
           [\d \! \?]]
-         ))))
+         )))
+  (testing "inserting newlines"
+    (is (=
+         (insert-char-in-buffer @example-buffer [1 0] \newline)
+
+         [[\r]
+          [\a]
+          [\d \!]]
+         ))
+    (is (=
+         (insert-char-in-buffer @example-buffer [1 1] \newline)
+
+         [[\r \a] [\d] [\!]]
+         ))
+    (is (=
+         (insert-char-in-buffer @example-buffer [0 0] \newline)
+
+         [[] [\r \a] [\d \!]]))
+    (is (=
+         (insert-char-in-buffer @example-buffer [2 1] \newline)
+         [[\r \a] [\d \!] []]))))
 
 (deftest print-buffer-tests
   (testing "printing a line"


### PR DESCRIPTION
When inserting a `\newline` char, make a new line after the point, set the x of point to 0, and y to y+1. 

Make a newline and put point on the first column of the new line. 
