### PR TITLE
rad.core/move-point-forward smart about buffers & rad.terminal prints multiple lines

### DIFF
--- a/src/rad/buffer.clj
+++ b/src/rad/buffer.clj
@@ -29,7 +29,6 @@
     ;; r
     ;; a
     ;; d!
-    
     \newline (let [point-x (first point)
                    point-y (second point)
                    current-line (buffer point-y)
@@ -39,18 +38,14 @@
                    rest-of-current-line (subvec current-line point-x)          ;; one line
                    every-line-below-current-line (subvec buffer (+ 1 point-y)) ;; collection of lines
 
-                   ;; let's do it all in the let
                    every-line-above-plus-current-until-point (conj every-line-above-current-line current-line-until-point)
                    above-current-plus-rest-of-current (conj every-line-above-plus-current-until-point rest-of-current-line)
 
                    ;; Here is the last bug. I'm adding a collection into another collection.
                    ;; What I want to do is to add every item of every-line-below-current-line into above-current-plus-rest-of-current
-                   the-whole-pancake (into above-current-plus-rest-of-current every-line-below-current-line)
-                   ]
+                   the-whole-new-line (into above-current-plus-rest-of-current every-line-below-current-line)]
+               the-whole-new-line)
 
-               the-whole-pancake)
-
-    
     ;; else
     (assoc buffer (second point) (insert-char-in-line
                                   (buffer (second point)) ;y - line
@@ -81,6 +76,9 @@
   [buffer]
   {:pre  [buffer?]
    :post [string?]}
-  (do
-    (println buffer)
-    (clojure.string/join "\n" (map line->string buffer))))
+  (clojure.string/join "\n" (map line->string buffer)))
+
+(defn buffer->list-of-strings
+  "Takes a buffer, and returns a list of every line, represented as a string"
+  [buffer]
+  (into [] (map line->string buffer)))

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -9,9 +9,19 @@
 
 ;; FIXME understand newlines
 (defn move-point-forward
-  "Returns point 'steps' steps forward until it hits a newline.
-  Then go to next line (not implemented)"
-  [point steps] (assoc point (first point) (+ (first point) steps)))
+  "Returns point 'steps' steps forward until it hits a newline."
+  [buffer point steps] (let [line (buffer (second point))
+                             point-x (first point)
+                             point-y (second point)
+                             can-move-forward? (fn [line p-x]
+                                                 (not (>= p-x (count line))))]
+
+                         (if (can-move-forward? line point-x)
+                           (recur
+                            buffer
+                            [(+ 1 point-x) point-y] ;; one step forward
+                            (- steps 1))
+                           point)))
 
 (defn sync-frontend-cursor-to-point-atom!
   "Updates the cursor in whatever front end is active"
@@ -21,21 +31,32 @@
 (defn move-point-forward!
   "Moves point 'steps' steps, and also updates the UI cursor"
   [steps] (do
-            (reset! point (move-point-forward @point 1))
+            (reset! point (move-point-forward @rad.buffer/current-buffer @point 1))
             (sync-frontend-cursor-to-point-atom!)))
+
+(defn alphanumeric?
+  "Returns true if char is either a letter or a number"
+  [char]
+  (if (char? char)
+    (not (nil? (re-matches #"^[0-9a-zA-Z ]+$" (str char))))
+    false))
 
 (defn handle-keypress!
   "Takes a key press, and delegates it into the proper action
 
-  Todos: 
+  Todos:
   * Make it front-end agnostic - now it depends on many things from the terminal front end"
-  [key] (do (println (str "keypress: " key))
-            (if (= :enter key) ;; replace with fn frontend/normalize-key
+  [key] (do
+          (println (str "keypress: " key))
+          (if (= :enter key) ;; replace with fn frontend/normalize-key
+            (do
               (buffer/insert-char! @point \newline)
-              
-              (buffer/insert-char! @point key))
-            (move-point-forward! 1)
-            (terminal/render-buffer! @buffer/current-buffer terminal/scr)))
+              ;; move point to one line down x=0, y=y+1
+              (reset! point [0 (+ 1 (second @point))]))
+
+            (buffer/insert-char! @point key))
+          (move-point-forward! 1)
+          (terminal/render-buffer! @buffer/current-buffer terminal/scr)))
 
 (defn -main []
   (do
@@ -43,5 +64,4 @@
 ;    (rad.swt/start-gui-threaded))
 
     (terminal/init-terminal! terminal/scr)
-    (terminal/get-keypress-keepalive-loop terminal/scr handle-keypress!)
-    ))
+    (terminal/get-keypress-keepalive-loop terminal/scr handle-keypress!)))

--- a/src/rad/terminal.clj
+++ b/src/rad/terminal.clj
@@ -22,11 +22,24 @@
   [point] (s/move-cursor scr (first point) (second point)))
 
 (defn render-buffer!
-  "Renders a buffer to the terminal. This happens a lot."
+  "Renders a buffer to the terminal. This happens a lot. Fixme remomve dependency on rad.buffer"
   [buffer scr]
   (do
     (s/clear scr)
-    (s/put-string scr 1 0 (buffer/buffer->string buffer))
+    (println buffer)
+
+    (let [buffer-as-lines-of-strings (rad.buffer/buffer->list-of-strings buffer)]
+      (loop [amount-of-lines-left-to-print (dec (count buffer-as-lines-of-strings))
+             index 0]
+
+        (s/put-string scr 0 index
+                      (buffer-as-lines-of-strings index))
+
+        (if (> amount-of-lines-left-to-print 0)
+          (recur (dec amount-of-lines-left-to-print)
+                 (inc index))
+          "done")))
+
     (s/redraw scr)))
 
 (render-buffer! @buffer/current-buffer scr)

--- a/test/rad/buffer_test.clj
+++ b/test/rad/buffer_test.clj
@@ -78,4 +78,10 @@
   (testing "printing a whole buffer"
     (is (=
          "ra\nd!"
-         (buffer->string @example-buffer)))))
+         (buffer->string @example-buffer))))
+
+  (testing "printing a buffer like this [\"first line\" \"second line\"]"
+    ;; maybe this should be the default behaviour?
+    (is (=
+         ["ra" "d!"]
+         (buffer->list-of-strings @example-buffer)))))

--- a/test/rad/core_test.clj
+++ b/test/rad/core_test.clj
@@ -2,8 +2,37 @@
   (:require [clojure.test :refer :all]
             [rad.core :refer :all]))
 
-(deftest point-tests
-  (testing "Moving the point 5 steps"
+(def test-buffer (atom [[\r \a \d]
+                        [\i \s]
+                        [\m \e \a \n \t]
+                        [\t \o]
+                        [\b \e]
+                        [\h \a \c \k \e \d]
+                        ]))
+
+(deftest insertion-tests
+  (testing "Determining whether input is meant to go into buffer, or key-commands"
     (is (=
-         [5 0]
-         (move-point-forward [0 0] 5)))))
+         true
+         (alphanumeric? \a))
+
+        (=
+         false
+         (alphanumeric? :down))
+        (=
+         false
+         (alphanumeric? "h")))))
+
+(deftest point-tests
+  (testing "Moving the point"
+    (is (=
+         [3 0]
+         (move-point-forward @test-buffer [2 0] 1)))
+    (is (=
+         [3 0]
+         (move-point-forward @test-buffer [3 0] 1))))
+
+  (testing "Moving point to the edges"
+    (is (=
+         [2 4]
+         (move-point-forward @test-buffer [2 4] 5)))))


### PR DESCRIPTION
## Sorry! Two changes in one commit:
- move-point-forward is smart about buffers, and will not move the point
  if it would result in a out-of-bounds exception. Instead point will
  stop at the last char in a line.
- rad.terminal will print each line in a buffer on a new line in the
  terminal. The old behaviour just printed everything in one line,
  disregarding the newlines.
