### PR TITLE
mode

### DIFF
--- a/src/rad/buffer.clj
+++ b/src/rad/buffer.clj
@@ -35,6 +35,11 @@
            (vector current-line-without-deleted-char))
      all-lines-below-current)))
 
+(defn delete-char-in-current-buffer!
+  "Does what it says, and mutates the current-buffer"
+  [point]
+  (reset! current-buffer (delete-char-in-buffer @current-buffer point)))
+
 (defn delete-char-backwards
   "Deletes a char in a buffer one column before point-x"
   [buffer point]
@@ -46,6 +51,11 @@
   "Deletes a char backwards from @point, and saves it to @current-buffer"
   [point]
   (reset! current-buffer (delete-char-backwards @current-buffer point)))
+
+(defn delete-char-at-current-point!
+  "Deleter whatever is in front of point. That's the point!"
+  []
+  (delete-char-in-current-buffer! [0 0])) ; FIXME FIXME FIXME
 
 (defn insert-char-in-line
   "Returns a new line with column 'point' replaces with new alphanumeric"

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -14,33 +14,11 @@
     (not (nil? (re-matches #"^[0-9a-zA-Z ]+$" (str char))))
     false))
 
-(defn insert-mode-handle-keypress!
-  "Takes a key press, and delegates it into the proper action
-
-  Todos:
-  * Make it front-end agnostic - now it depends on many things from the terminal front end"
-  [key] (do
-          (condp = key
-            :enter (do
-                     (buffer/insert-char! @rad.point/point \newline)
-                     ;; move point to one line down x=0, y=y+1
-                     (reset! rad.point/point [0 (+ 1 (second @rad.point/point))])
-                     (rad.point/sync-frontend-cursor-to-point-atom!))
-            :backspace (do
-                         (buffer/delete-char-backwards! @rad.point/point)
-                         (rad.point/move-point-backwards! 1))
-
-            ;; else
-            (do  (buffer/insert-char! @rad.point/point key)
-                 (rad.point/move-point-forward! 1)))
-
-          (println (str "keypress: " key ", point: " @rad.point/point))
-          (terminal/render-buffer! @buffer/current-buffer terminal/scr)))
 
 (defn handle-keypress! [key]
   (if (= :command @rad.mode/current-mode)
     (rad.mode/command-mode-handle-key! key)
-    (insert-mode-handle-keypress! key)))
+    (rad.mode/insert-mode-handle-keypress! key)))
 
 (defn -main []
   (do

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -14,7 +14,6 @@
     (not (nil? (re-matches #"^[0-9a-zA-Z ]+$" (str char))))
     false))
 
-
 (defn handle-keypress! [key]
   (if (= :command @rad.mode/current-mode)
     (rad.mode/command-mode-handle-key! key)

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -3,61 +3,9 @@
   (:require [rad.terminal :as terminal]
             [rad.swt]
             [rad.buffer :as buffer]
-            [rad.mode]))
-
-;; point is x & y position of the point (or cursor)
-(def point (atom [0 0]))
-(declare sync-frontend-cursor-to-point-atom! move-point-backwards! move-point-backwards)
-
-(defn move-point-backwards
-  "Returns point 'steps' steps backwards until it hits a beginning-of-line"
-  [buffer point steps]
-  (let [can-move-backwards? (fn [point-x]
-                              (> point-x 0))]
-    (loop [line (buffer (second point))
-           point-x (first point)
-           steps steps]
-      (if (and
-           (> steps 0)
-           (can-move-backwards? point-x))
-
-        (recur line (dec point-x) (dec steps))
-        [point-x (second point)]))))
-
-(defn move-point-backwards!
-  "Moves point 'steps' steps backwards, and syncs the UI cursor"
-  [steps] (do
-            (reset! point (move-point-backwards @rad.buffer/current-buffer @point steps))
-            (sync-frontend-cursor-to-point-atom!)))
-
-(defn move-point-forward
-  "Returns point 'steps' steps forward until it hits a newline."
-  [buffer point steps]
-  (let [point-x (first point)
-        point-y (second point)
-        line (buffer point-y)
-        can-move-forward? (fn [line p-x]
-                            (not (>= p-x (count line))))]
-
-    (if (and
-         (> steps 0)
-         (can-move-forward? line point-x))
-      (recur
-       buffer
-       [(inc point-x) point-y] ;; one step forward
-       (- steps 1))
-      point)))
-
-(defn sync-frontend-cursor-to-point-atom!
-  "Updates the cursor in whatever front end is active"
-  []
-  (terminal/move-cursor-in-terminal! @point))
-
-(defn move-point-forward!
-  "Moves point 'steps' steps, and also updates the UI cursor"
-  [steps] (do
-            (reset! point (move-point-forward @rad.buffer/current-buffer @point 1))
-            (sync-frontend-cursor-to-point-atom!)))
+            [rad.mode]
+            [rad.point]
+            :reload-all))
 
 (defn alphanumeric?
   "Returns true if char is either a letter or a number"
@@ -74,19 +22,19 @@
   [key] (do
           (condp = key
             :enter (do
-                     (buffer/insert-char! @point \newline)
+                     (buffer/insert-char! @rad.point/point \newline)
                      ;; move point to one line down x=0, y=y+1
-                     (reset! point [0 (+ 1 (second @point))])
-                     (sync-frontend-cursor-to-point-atom!))
+                     (reset! rad.point/point [0 (+ 1 (second @rad.point/point))])
+                     (rad.point/sync-frontend-cursor-to-point-atom!))
             :backspace (do
-                         (buffer/delete-char-backwards! @point)
-                         (move-point-backwards! 1))
+                         (buffer/delete-char-backwards! @rad.point/point)
+                         (rad.point/move-point-backwards! 1))
 
             ;; else
-            (do  (buffer/insert-char! @point key)
-                 (move-point-forward! 1)))
+            (do  (buffer/insert-char! @rad.point/point key)
+                 (rad.point/move-point-forward! 1)))
 
-          (println (str "keypress: " key ", point: " @point))
+          (println (str "keypress: " key ", point: " @rad.point/point))
           (terminal/render-buffer! @buffer/current-buffer terminal/scr)))
 
 (defn handle-keypress! [key]

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -2,7 +2,8 @@
   (:gen-class)
   (:require [rad.terminal :as terminal]
             [rad.swt]
-            [rad.buffer :as buffer]))
+            [rad.buffer :as buffer]
+            [rad.mode]))
 
 ;; point is x & y position of the point (or cursor)
 (def point (atom [0 0]))
@@ -65,7 +66,7 @@
     (not (nil? (re-matches #"^[0-9a-zA-Z ]+$" (str char))))
     false))
 
-(defn handle-keypress!
+(defn insert-mode-handle-keypress!
   "Takes a key press, and delegates it into the proper action
 
   Todos:
@@ -87,6 +88,11 @@
 
           (println (str "keypress: " key ", point: " @point))
           (terminal/render-buffer! @buffer/current-buffer terminal/scr)))
+
+(defn handle-keypress! [key]
+  (if (= :command @rad.mode/current-mode)
+    (rad.mode/command-mode-handle-key! key)
+    (insert-mode-handle-keypress! key)))
 
 (defn -main []
   (do

--- a/src/rad/mode.clj
+++ b/src/rad/mode.clj
@@ -1,0 +1,57 @@
+(ns rad.mode
+  "State and functions for entering/leaving modes such as :insert and :command"
+  (:require [rad.buffer]
+            [rad.terminal]))
+
+;; This works only in repl right now ;)
+
+;; A rad command is a function. If it returns another function, it will not evaluate. If you give it something which is not fn?, it will evaluate.
+;; To make commands which take arguments - they return a function that takes a function. This creates a chain, and that chain is the arguments.
+
+(def current-mode (atom :command))           ; nil deafult to insert mode ; FIXME
+
+(defn rep
+  "Runs f n times"
+  [n f & acc]
+  (if (< 0 n)
+    (recur (dec n) f (conj acc (f)))
+    acc))
+
+(defn r []                              ;make me a macro
+  (fn [n]
+    (fn [f]
+      (rep n f))))
+
+(defn key-map [] {\r r
+                  \d rad.buffer/delete-char-at-current-point!})
+
+(defn get-value-for-key
+  "Translates from input key to what function/argument type should be put in the command
+  Numbers get returned as they are, when keys which have a value in the key-map will get their value returned"
+  [key]
+  (if (number? key)
+    key
+    (get (key-map) key)))
+
+(def current-command-state (atom nil))
+(defn command-mode-handle-key! [key]
+  (println key)
+  (let [command (get-value-for-key key)]
+    (if (fn? @current-command-state)
+      (if (nil? command)
+        (reset! current-command-state nil)
+        (reset! current-command-state (@current-command-state command)))
+      (reset! current-command-state (command))))
+  (println (str "keypress: " key))
+  (rad.terminal/render-buffer! @rad.buffer/current-buffer rad.terminal/scr))
+
+;; (deref current-command-state)
+;; (handle-key! :r)
+;; (handle-key! 3)
+;; (handle-key! :esc)
+
+
+;; (handle-key! :d)
+;; (reset! rad.buffer/current-buffer [[\r \a \d \. \i \s \. \a \n \. \e \d \i \t \o \r]
+;;                                    [\s \e \c \o \n \d \. \l \i \n \e]])
+;; @rad.core/point

--- a/src/rad/mode.clj
+++ b/src/rad/mode.clj
@@ -1,7 +1,8 @@
 (ns rad.mode
   "State and functions for entering/leaving modes such as :insert and :command"
   (:require [rad.buffer]
-            [rad.terminal]))
+            [rad.terminal]
+            [rad.point]))
 
 ;; This works only in repl right now ;)
 
@@ -44,6 +45,29 @@
       (reset! current-command-state (command))))
   (println (str "keypress: " key))
   (rad.terminal/render-buffer! @rad.buffer/current-buffer rad.terminal/scr))
+
+(defn insert-mode-handle-keypress!
+  "Takes a key press, and delegates it into the proper action
+
+  Todos:
+  * Make it front-end agnostic - now it depends on many things from the terminal front end"
+  [key] (do
+          (condp = key
+            :enter (do
+                     (rad.buffer/insert-char! @rad.point/point \newline)
+                     ;; move point to one line down x=0, y=y+1
+                     (reset! rad.point/point [0 (+ 1 (second @rad.point/point))])
+                     (rad.point/sync-frontend-cursor-to-point-atom!))
+            :backspace (do
+                         (rad.buffer/delete-char-backwards! @rad.point/point)
+                         (rad.point/move-point-backwards! 1))
+
+            ;; else
+            (do  (rad.buffer/insert-char! @rad.point/point key)
+                 (rad.point/move-point-forward! 1)))
+
+          (println (str "keypress: " key ", point: " @rad.point/point))
+          (rad.terminal/render-buffer! @rad.buffer/current-buffer rad.terminal/scr)))
 
 ;; (deref current-command-state)
 ;; (handle-key! :r)

--- a/src/rad/mode.clj
+++ b/src/rad/mode.clj
@@ -1,15 +1,16 @@
 (ns rad.mode
-  "State and functions for entering/leaving modes such as :insert and :command"
+  "State and functions for entering/leaving modes such as 'insert mode' and 'command mode'."
   (:require [rad.buffer]
             [rad.terminal]
             [rad.point]))
-
-;; This works only in repl right now ;)
 
 ;; A rad command is a function. If it returns another function, it will not evaluate. If you give it something which is not fn?, it will evaluate.
 ;; To make commands which take arguments - they return a function that takes a function. This creates a chain, and that chain is the arguments.
 
 (def current-mode (atom :command))           ; nil deafult to insert mode ; FIXME
+(defn change-mode!
+  ([] (change-mode! nil))
+  ([mode]  (reset! current-mode mode)))
 
 (defn rep
   "Runs f n times"
@@ -23,16 +24,17 @@
     (fn [f]
       (rep n f))))
 
-(defn key-map [] {\r r
-                  \d rad.buffer/delete-char-at-current-point!})
+(defn command-mode-key-map [] {\r r
+                               \d rad.buffer/delete-char-at-current-point!
+                               :escape change-mode!})
 
 (defn get-value-for-key
   "Translates from input key to what function/argument type should be put in the command
-  Numbers get returned as they are, when keys which have a value in the key-map will get their value returned"
+  Numbers get returned as they are, when keys which have a value in the command-mode-key-map will get their value returned"
   [key]
   (if (number? key)
     key
-    (get (key-map) key)))
+    (get (command-mode-key-map) key)))
 
 (def current-command-state (atom nil))
 (defn command-mode-handle-key! [key]
@@ -53,6 +55,7 @@
   * Make it front-end agnostic - now it depends on many things from the terminal front end"
   [key] (do
           (condp = key
+            :escape (change-mode! :command)
             :enter (do
                      (rad.buffer/insert-char! @rad.point/point \newline)
                      ;; move point to one line down x=0, y=y+1

--- a/src/rad/point.clj
+++ b/src/rad/point.clj
@@ -1,0 +1,57 @@
+(ns rad.point
+  (:require [rad.terminal]))
+
+;; point is x & y position of the point (or cursor)
+(def point (atom [0 0]))
+(declare move-point-backwards! move-point-backwards)
+
+(defn sync-frontend-cursor-to-point-atom!
+  "Updates the cursor in whatever front end is active"
+  []
+  (rad.terminal/move-cursor-in-terminal! @rad.point/point))
+
+(defn move-point-backwards
+  "Returns point 'steps' steps backwards until it hits a beginning-of-line"
+  [buffer point steps]
+  (let [can-move-backwards? (fn [point-x]
+                              (> point-x 0))]
+    (loop [line (buffer (second point))
+           point-x (first point)
+           steps steps]
+      (if (and
+           (> steps 0)
+           (can-move-backwards? point-x))
+
+        (recur line (dec point-x) (dec steps))
+        [point-x (second point)]))))
+
+(defn move-point-backwards!
+  "Moves point 'steps' steps backwards, and syncs the UI cursor"
+  [steps] (do
+            (reset! point (move-point-backwards @rad.buffer/current-buffer @point steps))
+            (sync-frontend-cursor-to-point-atom!)))
+
+(defn move-point-forward
+  "Returns point 'steps' steps forward until it hits a newline."
+  [buffer point steps]
+  (let [point-x (first point)
+        point-y (second point)
+        line (buffer point-y)
+        can-move-forward? (fn [line p-x]
+                            (not (>= p-x (count line))))]
+
+    (if (and
+         (> steps 0)
+         (can-move-forward? line point-x))
+      (recur
+       buffer
+       [(inc point-x) point-y] ;; one step forward
+       (- steps 1))
+      point)))
+
+
+(defn move-point-forward!
+  "Moves point 'steps' steps, and also updates the UI cursor"
+  [steps] (do
+            (reset! point (move-point-forward @rad.buffer/current-buffer @point 1))
+            (sync-frontend-cursor-to-point-atom!)))

--- a/src/rad/terminal.clj
+++ b/src/rad/terminal.clj
@@ -8,8 +8,8 @@
             [rad.buffer :as buffer]))
 (require '[lanterna.screen :as s])
 
-;;(def scr (s/get-screen :text))
-(def scr (s/get-screen)) ;; just for now
+(def scr (s/get-screen :text))
+;;(def scr (s/get-screen)) ;; just for now
 
 (defn init-terminal!
   [scr]
@@ -21,7 +21,7 @@
   [point] (s/move-cursor scr (first point) (second point)))
 
 (defn render-buffer!
-  "Renders a buffer to the terminal. This happens a lot. Fixme remomve dependency on rad.buffer"
+  "Renders a buffer to the terminal. This happens a lot"
   [buffer scr]
   (do
     (s/clear scr)

--- a/src/rad/terminal.clj
+++ b/src/rad/terminal.clj
@@ -15,7 +15,6 @@
   [scr]
   (s/start scr)
 
-  (s/put-string scr 10 10 "hello")
   (s/redraw scr))
 
 (defn move-cursor-in-terminal!

--- a/test/rad/mode_test.clj
+++ b/test/rad/mode_test.clj
@@ -1,0 +1,19 @@
+(ns rad.mode-test
+  (:require [clojure.test :refer :all]
+            [rad.mode :refer :all]))
+
+(deftest mode-tests
+  (testing "function that can find the meaning of keys, mapped to values"
+    (= (get-value-for-key :d)
+       '(rad.buffer/delete-char-in-current-buffer!)))
+
+  (testing "")
+
+  (testing "function that can search and build a list to evaluate, containing a fair share of state"
+    (= (do
+         (reset! command-build-state '())
+         (build-command 3)
+         (build-command :d) ;Means delete
+         (build-command :l)) ;means forward. hjkl is good for movement, all on home row
+       '(rad.buffer/delete-char-in-current-buffer! @point 3))) ; This is the list the function build. Notice how it's very (eval)-able?
+  )

--- a/test/rad/mode_test.clj
+++ b/test/rad/mode_test.clj
@@ -4,16 +4,4 @@
 
 (deftest mode-tests
   (testing "function that can find the meaning of keys, mapped to values"
-    (= (get-value-for-key :d)
-       '(rad.buffer/delete-char-in-current-buffer!)))
-
-  (testing "")
-
-  (testing "function that can search and build a list to evaluate, containing a fair share of state"
-    (= (do
-         (reset! command-build-state '())
-         (build-command 3)
-         (build-command :d) ;Means delete
-         (build-command :l)) ;means forward. hjkl is good for movement, all on home row
-       '(rad.buffer/delete-char-in-current-buffer! @point 3))) ; This is the list the function build. Notice how it's very (eval)-able?
-  )
+    (fn? (get-value-for-key \d))))

--- a/todo.org
+++ b/todo.org
@@ -1,6 +1,8 @@
 * Roadmap / todo-list
 ** DONE Move point-handling functions into their own ns, instead of rad.core
    CLOSED: [2015-09-07 Mon 21:36]
+** DONE Move insert-mode-handle-key to rad.mode
+   CLOSED: [2015-09-07 Mon 21:47]
 ** TODO Make plugin system (basically (load-file) every file in ~/.rad/plugins
 ** TODO Start terminal gui in thread
 ** TODO Use SWT instead

--- a/todo.org
+++ b/todo.org
@@ -1,12 +1,16 @@
-* Roadmap / todo-list
-** DONE Move point-handling functions into their own ns, instead of rad.core
+* DONE Move point-handling functions into their own ns, instead of rad.core
    CLOSED: [2015-09-07 Mon 21:36]
-** DONE Move insert-mode-handle-key to rad.mode
+* DONE Move insert-mode-handle-key to rad.mode
    CLOSED: [2015-09-07 Mon 21:47]
-** DONE Mode switching
+* DONE Mode switching
    CLOSED: [2015-09-07 Mon 22:05]
 
+* DONE Clean up mode tests
+  CLOSED: [2015-09-08 Tue 21:56]
+* TODO Make clearer names in command mode
 
-** TODO Make plugin system (basically (load-file) every file in ~/.rad/plugins
-** TODO Start terminal gui in thread
-** TODO Use SWT instead
+* TODO Make plugin system (basically (load-file) every file in ~/.rad/plugins
+* TODO Start terminal gui in thread
+
+* TODO Use SWT instead
+* TODO Whenever a keypress has the Ctrl key pressed, route it thru command mode

--- a/todo.org
+++ b/todo.org
@@ -1,10 +1,7 @@
 * Roadmap / todo-list
-** TODO *earmuff* important vars such as buffer/current-buffer, point, etc
-** TODO Move point-handling functions into their own ns, instead of rad.core
+** DONE Move point-handling functions into their own ns, instead of rad.core
+   CLOSED: [2015-09-07 Mon 21:36]
 ** TODO Make plugin system (basically (load-file) every file in ~/.rad/plugins
-** DONE handle-keypress! understand backspace (delete backwards -> move cursor 1 step back
-   CLOSED: [2015-07-21 Tue 21:14]
-*** TODO Make rad.core/move-point-backwards (the pure one)
-** DONE move-point-forward should take an arbitrary number of steps (not does 1)
-   CLOSED: [2015-07-21 Tue 21:15]
-** TODO Update Readme
+** TODO Start terminal gui in thread
+** TODO Use SWT instead
+** TODO Mode switching

--- a/todo.org
+++ b/todo.org
@@ -3,7 +3,10 @@
    CLOSED: [2015-09-07 Mon 21:36]
 ** DONE Move insert-mode-handle-key to rad.mode
    CLOSED: [2015-09-07 Mon 21:47]
+** DONE Mode switching
+   CLOSED: [2015-09-07 Mon 22:05]
+
+
 ** TODO Make plugin system (basically (load-file) every file in ~/.rad/plugins
 ** TODO Start terminal gui in thread
 ** TODO Use SWT instead
-** TODO Mode switching


### PR DESCRIPTION
Rad is a modal editor (much like vi). As of now, it has a `insert` mode and `command` mode. 

In insert mode, most keys do what you'd expect. Hitting `q` will insert a `q` at point. Backspace does what you expect it. 

When you switch to `command mode`, the keys will run other functions. If the function mapped to a key returns a function, you will build a chain of evaluation. 

For instance, if the `r` function (activated with the r key); it returns a function which takes a number. That function returns a function that takes another function. Each time a function is returned by a command, the next key press will be the argument to that returned function. 

Whenever a command returns something which is `(not (fn? *command*))`, then the whole command chain will be executed. In this way, hitting `r3dw` expands into `repeat 3 times: delete word`. `r` returns 2 levels of functions. The first one takes the number 3. The second one takes the function `delete` (given by the key `d`). The `d` returns a function, which argument will be the length of are to be deleted. 
