### PR TITLE
Rad exits when rad.state/shutdown-chan receives a message

### DIFF
--- a/docs/frontends.md
+++ b/docs/frontends.md
@@ -60,13 +60,9 @@ When that happens, the new buffer or point will be put onto the `:print-chan` & 
 
 ## How to shut down rad from a front-end?
 
-When you want to shut down rad, you set `(:should-exit @rad.state/config)` to true.
+To tell Rad to shut off, do `(clojure.core.async/put! rad.state/shutdown-chan :exit)`.
 
 When Rad is done with whatever it is doing, it will shut down. That behaviour is defined in `rad.core/-main`.
-
-``` clojure
-(swap! rad.state/config update :should-exit? not)
-```
 
 ## Roadmap
 

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -39,7 +39,5 @@
     (rad.mode/handle-keypress! (<! in-c))
     (recur))
 
-  (loop []
-    (if-not (:should-exit? @rad.state/config)
-      (recur)
-      (println "Exiting Rad..."))))
+  (a/<!! rad.state/shutdown-chan) ; this is how rad is told to exit
+  (println "Exiting Rad..."))

--- a/src/rad/frontend/fx.clj
+++ b/src/rad/frontend/fx.clj
@@ -88,7 +88,7 @@
                             :shortcut-down? (.isShortcutDown event)})))})
      (fx/pset! stage
                {:on-close-request
-                (fn [_] (swap! rad.state/config update :should-exit? not))})
+                (fn [_] (a/put! rad.state/shutdown-chan :exit))})
 
      (fx/set-global-css! [[:* {:-fx-font-family "monaco, Consolas, 'Lucida Console', monospace"}]
                           [:.point {:-fx-background-color "limegreen"}]])

--- a/src/rad/state.clj
+++ b/src/rad/state.clj
@@ -1,6 +1,7 @@
 (ns rad.state
-  "Contains shared state for rad.")
+  "Contains shared state for rad."
+  (:require [clojure.core.async :refer [chan]]))
 
 (def loaded-packages (atom []))
 
-(def config (atom {:should-exit? false}))
+(def shutdown-chan (chan))


### PR DESCRIPTION
<img width="689" alt="screen shot 2016-03-10 at 13 50 06" src="https://cloud.githubusercontent.com/assets/1630938/13668904/7c77f598-e6c8-11e5-967e-3be4903f1c84.png">
Fixes #32 
