### PR TITLE
Wrap packages in [] to make them pure data

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,8 @@ Rad (currently) has 2 modes. They are defined in `rad.mode`.
 Rad packages are crazy simple. They have exactly the same form as a Clojure `ns` macro.
 Only difference is: a rad package requires a `docstring` and an `attr-map`.
 
+Rad packages are a vector where the first element is a ns declaration. Think a normal clojure file, wrapped in `[]`.
+
 All packages in `~/.rad/packages` will be loaded upon startup.
 
 All standard packages that are distributed along with Rad are located in `../standard-packages/`.

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -12,9 +12,9 @@
 (Thread/setDefaultUncaughtExceptionHandler
  (reify Thread$UncaughtExceptionHandler
    (uncaughtException [_ thread throwable]
-     (println "\n\nOh no!\n\n")
-     (clojure.stacktrace/print-stack-trace throwable)
-     (-> throwable .getStackTrace clojure.stacktrace/print-stack-trace)
+     (println "\nOh no!\n")
+     (println (clojure.stacktrace/print-stack-trace throwable))
+     (println "\n さようなら \n")
      (System/exit 1))))
 
 (defn -main [& args]
@@ -27,7 +27,7 @@
 
   (go (package/load-all-packages-in-dir! "standard-packages")
       (package/load-all-packages-in-dir! (str (System/getProperty "user.home")
-                                           "/.rad/packages")))
+                                              "/.rad/packages")))
 
   (go-loop []
     (a/>! out-c (<! rad.buffer/buffer-updates-channel))

--- a/src/rad/package.clj
+++ b/src/rad/package.clj
@@ -1,32 +1,52 @@
 (ns rad.package
   (:require [rad.state]
-            [clojure.tools.namespace.file]))
+            [clojure.java.io :as io]))
+
+(defn package?
+  "Package data structure predicate"
+  [package]
+  (and (vector? package)
+       (list? (first package))
+       (= 'ns (first (first package)))
+       (map? (nth (first package) 3))))
 
 (defn load-package!
-  "Loads a package (which is a ns with some special metadata) into Rad"
+  "Loads a package into Rad"
   [package]
+  {:pre [(package? package)]}
+  ;; Hack because Clojure namespaces are not pure data
+  (binding [*ns* (first (first package))]
+    (in-ns (first (first package))) ;; without AOT can't work
+    (run! eval package))
   (swap! rad.state/loaded-packages conj package))
 
 (defn get-key-map-from-package [package]
-  (:command-map (eval (nth package 3))))
+  (:command-map (eval (nth (first package) 3))))
 
 (defn merge-package-command-maps [packages-list]
   (into {} (map get-key-map-from-package packages-list)))
 
-(defn get-in-evaled                     ;utility
+(defn get-in-evaled
   "Returns the evaled result of clojure.core/get-in"
   [m ks]
   (eval (get-in m ks)))
 
-(defn load-package-from-file! [file-path]
-  (load-file file-path)                 ;Load into the Lisp enviroment
-  (load-package!                        ;Load into the Rad enviroment
-   (clojure.tools.namespace.file/read-file-ns-decl file-path)))
+(defn get-package-from-file [file-path]
+  {:pre [(string? file-path)]
+   :post [(package? %)]}
+  (second (read-string (str "'[" (slurp file-path) "]"))))
 
 (defn clojure-files-in-dir [path]
   (->> (file-seq (clojure.java.io/file path))
        (map #(.getAbsolutePath %) ,)
        (filter #(re-find #".clj$" %) ,)))
 
+(defn get-all-packages-in-dir [path]
+  {:pre [(string? path)]
+   :post [(fn [pkgs] (map package? pkgs))]}
+  (map get-package-from-file (clojure-files-in-dir path)))
+
 (defn load-all-packages-in-dir! [path]
-  (run! load-package-from-file! (clojure-files-in-dir path)))
+  {:pre [(string? path)]}
+  (run! load-package! (get-all-packages-in-dir path))
+  @rad.state/loaded-packages)

--- a/test/rad/buffer_test.clj
+++ b/test/rad/buffer_test.clj
@@ -11,7 +11,7 @@
     (is (= "0123"
            (delete-char-in-line "01234" 4))))
 
-(testing "Deleting a char at point"
+  (testing "Deleting a char at point"
     (is (= ["Rad is meant" "o be hacked"]
            (delete-char-at-point ["Rad is meant" "to be hacked"] [0 1])))
     (is (= ["ra"]

--- a/test/rad/package_test.clj
+++ b/test/rad/package_test.clj
@@ -3,31 +3,42 @@
             [rad.package :refer :all]
             [rad.state]))
 
-(def example-packages ['(ns new-kind-of-package
-                          "A prototype for how a package can look"
+(def example-packages ['[(ns new-kind-of-package
+                           "A prototype for how a package can look"
+                           {:author {:name "Martin Josefsson"
+                                     :url "http://www.martinjosefsson.com"
+                                     :email "hello@martinjosefsson.com"}
+                            :people [{:name "Jesper Oskarsson"
+                                      :url "http://github.com/redien/reuse-lang"
+                                      :email "jesosk@gmail.com"}]
+                            :version "1.0.0"
+                            :repository "https://github.com/fromheten/rad/"
+                            :keywords #{:test :package}
+                            :homepage "http://www.example.org/"
+                            :bugs "http://www.example.org/bug-reports"
+                            :license "GPLv3"
+                            :bin {:ls "/bin/ls"}
+                            :dependencies [{:foo-package "2.3.4"}] ;; These packages will be loaded first
+                            :rad-version "0.4.3"
+                            :command-map '{\s (fn [] (new-kind-of-package/rad-name "tester"))
+                                           \r {\a (fn [] (println "it works!"))}}})
+                         (defn rad-name [name] (str "hello " name))]
 
-                          {:author {:name "Martin Josefsson"
-                                    :url "http://www.martinjosefsson.com"
-                                    :email "hello@martinjosefsson.com"}
-                           :people [{:name "Jesper Oskarsson"
-                                     :url "http://github.com/redien/reuse-lang"
-                                     :email "jesosk@gmail.com"}]
-                           :version "1.0.0"
-                           :repository "https://github.com/fromheten/rad/"
-                           :keywords #{:test :package}
-                           :homepage "http://www.example.org/"
-                           :bugs "http://www.example.org/bug-reports"
-                           :license "GPLv3"
-                           :bin {:ls "/bin/ls"}
-                           :dependencies [{:foo-package "2.3.4"}] ;; These packages will be loaded first
-                           :rad-version "0.4.3"
+                       '[(ns another-example-package
+                           "Another example"
+                           {:command-map '{\e (fn [] "2: pretty neat")
+                                           \r (fn [] "2: it still works")}})]])
 
-                           :command-map '{\s (fn [] (clojure.core/println "hello"))
-                                          \r (fn [] (println "it works!"))}})
-                       '(ns another-example-package
-                          "Another example"
-                          {:command-map '{\e (fn [] "2: pretty neat")
-                                         \r (fn [] "2: it still works")}})])
+(deftest package?-predicate
+  (testing "Valid packages are seen as such"
+    (is (package? '[(ns test-package
+                      "A test package, to be loaded from the file system"
+                      {:command-map '{\s (fn [] "Running a function from a package on disk")
+                                      \g (fn [] (say-hi "tester"))}})
+                    (defn say-hi [name]
+                      (str "hello " name))]))
+    (is (not (package? '(ns test-package "string" {:map (fn [] "func")}))))))
+
 (deftest package-loading
   (testing "Loading a package."
     ;; The format we save this list in is just a vector
@@ -41,47 +52,42 @@
        (keys (get-key-map-from-package (first example-packages)))))
 
   (testing "Merging all command maps in a collection of packages."
-    (let [merged-command-maps (merge-package-command-maps example-packages)]
-      (is (map? merged-command-maps))
-      (is (char? (first (keys merged-command-maps))))
-      (is (= #{\e \r \s}
-             (set (keys merged-command-maps))))
-      (is (= "hello"
-             ((fn [] "hello"))))
-      (is (= "2: pretty neat"
-             ((eval (get-in merged-command-maps [\e])))
-             ((get-in-evaled merged-command-maps [\e]))))))
+    (is (map? (merge-package-command-maps example-packages)))
+    (is (map char? (keys (merge-package-command-maps example-packages))))
+    (is (= #{\e \r \s}
+           (set (keys (merge-package-command-maps example-packages)))))
+    (is (= "hello" ((fn [] "hello"))))
+    (is (= "2: pretty neat"
+           ((eval (get-in (merge-package-command-maps example-packages) [\e])))
+           ((get-in-evaled (merge-package-command-maps example-packages) [\e])))))
 
   (testing "Loading a package from a file, and running a function from it."
     (testing "Loading a package from a file"
-      (reset! rad.state/loaded-packages [])
-      (load-package-from-file! "./test_packages/test_package.clj")
-      (is (= 1
-             (count @rad.state/loaded-packages))))
+      (is (package? (get-package-from-file "./test_packages/test_package.clj"))))
     (testing "Evaliating a function from its key-map"
       (reset! rad.state/loaded-packages [])
-      (load-package-from-file! "./test_packages/test_package.clj")
+      (load-package! (get-package-from-file "./test_packages/test_package.clj"))
       (is (= "Running a function from a package on disk"
              ((get-in-evaled
                (merge-package-command-maps @rad.state/loaded-packages)
-               [\s]))))
-      (is (= "hello tester"
-             ((get-in-evaled
-               (merge-package-command-maps @rad.state/loaded-packages)
-               [\g]))))))
+               [\s]))))))
+  (testing "getting a list of packages from directory"
+    (is (map package? (get-all-packages-in-dir "./test_packages/"))))
+
   (testing "Loading all packages in a directory"
     (is (= (do (reset! rad.state/loaded-packages [])
                (load-all-packages-in-dir! "./test_packages/")
                (count @rad.state/loaded-packages))
            (count (clojure-files-in-dir "./test_packages/")))))
+
   (testing "Loading package with command that uses fn in rad.package"
     (is (= (do (reset! rad.state/loaded-packages [])
                (load-package!
-                '(ns package-that-uses-rad.package-ns
-                   "Let's see if my implementation is worth anything..."
-                   {:command-map '{\p (fn [] (do (require 'rad.package)
-                                                 (rad.package/get-in-evaled
-                                                  {:it "works"} [:it])))}}))
+                '[(ns package-that-uses-rad.package-ns
+                    "Let's see if my implementation is worth anything..."
+                    {:command-map '{\p (fn [] (do (require 'rad.package)
+                                                  (rad.package/get-in-evaled
+                                                   {:it "works"} [:it])))}})])
                ((get-in-evaled
                  (merge-package-command-maps @rad.state/loaded-packages) [\p])))
            "works")))


### PR DESCRIPTION
Clojure namespaces are not a pure Clojure data structure. That is a problem if you want to pass them around between functions. 

Therefore in this patch I've wrapped them inside a vector `[]`. In this way, using `def` is not limited to packages defined in files, but are just another list inside the package. 

``` clojure
[(ns test-package
  "A test package, to be loaded from the file system"
  {:command-map '{\s (fn [] "Running a function from a package on disk")
                  \g (fn [] (test-package/say-hi "tester"))}})

(defn say-hi [name]
  (str "hello " name))]
```

Please note this is just a change in the internal data structure - packages loaded from files have the square brackets added to them before being loaded into Rad. 
