### PR TITLE
Move point and current-buffer into rad.state

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,7 +92,7 @@ This is the package I used for testing. It's very small but shows off what capab
                     {\p
                      {\p
                       {\y
-                       (fn [] (reset! rad.buffer/current-buffer
+                       (fn [] (reset! rad.state/current-buffer
                                       (replace-buffer-with-happy-message/message!)))}}}}}}})
 
 (println "Happy Hacking :)")

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -24,7 +24,7 @@ We will begin my making a package, that adds a command. When the package is load
                     {\p
                      {\p
                       {\y
-                       (fn [] (reset! rad.buffer/current-buffer ;; you can use any rad namespace, except for `rad.core`
+                       (fn [] (reset! rad.state/current-buffer ;; you can use any rad namespace, except for `rad.core`
                                 (replace-buffer-with-happy-message/message)))}}}}}}})
 
 (println "Happy Hacking :)")

--- a/src/rad/buffer.clj
+++ b/src/rad/buffer.clj
@@ -1,6 +1,7 @@
 (ns rad.buffer
   (:require [clojure.core.async :as a :refer [chan go >!]]
-            [rad.state]))
+            [rad.state]
+            [rad.point]))
 
 (defn delete-char-in-line
   "Returns line without the char at point"
@@ -35,9 +36,9 @@
 
 (defn delete-char-backwards!
   "What your backspace key does"
+  ([] (delete-char-backwards! @rad.state/point))
   ([point] (swap! rad.state/current-buffer
-                  #(delete-char-backwards-from-point %
-                                                     point))))
+                  #(delete-char-backwards-from-point % point))))
 
 (defn insert-char-in-line
   "Returns a string with `char' inserted at `point-y'"
@@ -65,12 +66,12 @@
 
 (defn insert-char!
   "Inserts one-char input at point"
-  [^String input point]
-  (do (reset!
-       rad.state/current-buffer
-       (insert-char-at-point @rad.state/current-buffer
-                             point
-                             input))))
+  ([input] (insert-char! input @rad.state/point))
+  ([^String input point] (do (reset! rad.state/current-buffer
+                                     (insert-char-at-point @rad.state/current-buffer
+                                                           point
+                                                           input))
+                             (rad.point/move-point-forward!))))
 
 (defn insert-new-line-at-line-number
   "Returns a buffer with a blank line at position `line-nr'"

--- a/src/rad/buffer.clj
+++ b/src/rad/buffer.clj
@@ -1,14 +1,6 @@
 (ns rad.buffer
-  (:require [clojure.core.async :as a :refer [chan go >!]]))
-
-(def current-buffer (atom ["Rad is meant"
-                           "to be hacked"]))
-(def buffer-updates-channel
-  (let [channel (chan)]
-    (add-watch current-buffer :_
-               (fn [_ _ _ new-state]
-                 (go (>! channel new-state))))
-    channel))
+  (:require [clojure.core.async :as a :refer [chan go >!]]
+            [rad.state]))
 
 (defn delete-char-in-line
   "Returns line without the char at point"
@@ -31,8 +23,8 @@
 (defn delete-char!
   "Opposite of insert-char!"
   ([point] (reset!
-            current-buffer
-            (delete-char-at-point @current-buffer
+            rad.state/current-buffer
+            (delete-char-at-point @rad.state/current-buffer
                                   point))))
 
 (defn delete-char-backwards-from-point
@@ -43,7 +35,7 @@
 
 (defn delete-char-backwards!
   "What your backspace key does"
-  ([point] (swap! current-buffer
+  ([point] (swap! rad.state/current-buffer
                   #(delete-char-backwards-from-point %
                                                      point))))
 
@@ -75,8 +67,8 @@
   "Inserts one-char input at point"
   [^String input point]
   (do (reset!
-       current-buffer
-       (insert-char-at-point @current-buffer
+       rad.state/current-buffer
+       (insert-char-at-point @rad.state/current-buffer
                              point
                              input))))
 
@@ -91,7 +83,7 @@
 
 (defn insert-new-line-at-line-number!
   "Inserts a new line into the current buffer"
-  ([line-nr] (swap! current-buffer insert-new-line-at-line-number line-nr)))
+  ([line-nr] (swap! rad.state/current-buffer insert-new-line-at-line-number line-nr)))
 
 (defn insert-new-line-below-point!
   [point] (insert-new-line-at-line-number! (inc (second point))))

--- a/src/rad/core.clj
+++ b/src/rad/core.clj
@@ -30,10 +30,10 @@
                                               "/.rad/packages")))
 
   (go-loop []
-    (a/>! out-c (<! rad.buffer/buffer-updates-channel))
+    (a/>! out-c (<! rad.state/buffer-updates-channel))
     (recur))
   (go-loop []
-    (a/>! point-c (<! rad.point/point-update-channel))
+    (a/>! point-c (<! rad.state/point-update-channel))
     (recur))
   (go-loop []
     (rad.mode/handle-keypress! (<! in-c))

--- a/src/rad/mode.clj
+++ b/src/rad/mode.clj
@@ -17,10 +17,10 @@
   [input]
   (if (keyword? input)
     (condp = input
-      :back_space (do (rad.buffer/delete-char-backwards! @rad.point/point)
+      :back_space (do (rad.buffer/delete-char-backwards! @rad.state/point)
                       (rad.point/move-point-backwards! 1))
       :tab (change-mode-to! :command)
-      :enter (do (rad.buffer/insert-new-line-below-point! @rad.point/point)
+      :enter (do (rad.buffer/insert-new-line-below-point! @rad.state/point)
                  (rad.point/move-point-to-beginning-of-line!)
                  (rad.point/move-point-down! 1))
       :up (rad.point/move-point-up!)
@@ -29,7 +29,7 @@
       :right (rad.point/move-point-forward!)
 
       (println (str "Can not handle input: " input)))
-    (do (rad.buffer/insert-char! input @rad.point/point)
+    (do (rad.buffer/insert-char! input @rad.state/point)
         (rad.point/move-point-forward!))))
 
 ;;; Command mode

--- a/src/rad/mode.clj
+++ b/src/rad/mode.clj
@@ -29,8 +29,7 @@
       :right (rad.point/move-point-forward!)
 
       (println (str "Can not handle input: " input)))
-    (do (rad.buffer/insert-char! input @rad.state/point)
-        (rad.point/move-point-forward!))))
+    (rad.buffer/insert-char! input @rad.state/point)))
 
 ;;; Command mode
 

--- a/src/rad/point.clj
+++ b/src/rad/point.clj
@@ -1,14 +1,7 @@
 (ns rad.point
   (:require [clojure.core.async :as a :refer [chan]]
+            [rad.state]
             [rad.buffer]))
-
-(def point (atom [0 0]))
-(def point-update-channel
-  (let [channel (chan)]
-    (add-watch point :_
-               (fn [_ _ _ new-state]
-                 (a/put! channel new-state)))
-    channel))
 
 (defn move-point-forward
   "Returns a point where the x position is incremented `steps' steps"
@@ -29,7 +22,7 @@
 (defn move-point-forward!
   "Moves point steps forward, defaults to 1"
   ([] (move-point-forward! 1))
-  ([steps] (swap! point move-point-forward steps @rad.buffer/current-buffer)))
+  ([steps] (swap! rad.state/point move-point-forward steps @rad.state/current-buffer)))
 
 (defn move-point-backwards
   "Returns a point where the x position is decremented `steps' steps"
@@ -43,7 +36,7 @@
 
 (defn move-point-backwards!
   ([] (move-point-backwards! 1))
-  ([steps] (swap! point move-point-backwards steps)))
+  ([steps] (swap! rad.state/point move-point-backwards steps)))
 
 (defn move-point-up
   "Returns a point where the y position is decremented `steps' steps"
@@ -56,7 +49,7 @@
 (defn move-point-up!
   "Moves point `steps' steps up. Defaults to 1 step."
   ([] (move-point-up! 1))
-  ([steps] (swap! point move-point-up steps @rad.buffer/current-buffer)))
+  ([steps] (swap! rad.state/point move-point-up steps @rad.state/current-buffer)))
 
 (defn move-point-down
   "Returns a point where the y position is decremented `steps' steps"
@@ -69,11 +62,11 @@
 
 (defn move-point-down!
   ([] (move-point-down! 1))
-  ([steps] (swap! point move-point-down steps @rad.buffer/current-buffer)))
+  ([steps] (swap! rad.state/point move-point-down steps @rad.state/current-buffer)))
 
 (defn move-point-to-beginning-of-line
   [point]
   [0 (second point)])
 
 (defn move-point-to-beginning-of-line! []
-  (swap! point move-point-to-beginning-of-line))
+  (swap! rad.state/point move-point-to-beginning-of-line))

--- a/src/rad/point.clj
+++ b/src/rad/point.clj
@@ -1,7 +1,6 @@
 (ns rad.point
   (:require [clojure.core.async :as a :refer [chan]]
-            [rad.state]
-            [rad.buffer]))
+            [rad.state]))
 
 (defn move-point-forward
   "Returns a point where the x position is incremented `steps' steps"

--- a/src/rad/state.clj
+++ b/src/rad/state.clj
@@ -1,7 +1,24 @@
 (ns rad.state
   "Contains shared state for rad."
-  (:require [clojure.core.async :refer [chan]]))
+  (:require [clojure.core.async :as a :refer [chan go >!]]))
 
 (def loaded-packages (atom []))
 
 (def shutdown-chan (chan))
+
+(def current-buffer (atom ["Rad is meant"
+                           "to be hacked"]))
+(def buffer-updates-channel
+  (let [channel (chan)]
+    (add-watch current-buffer :_
+               (fn [_ _ _ new-state]
+                 (go (>! channel new-state))))
+    channel))
+
+(def point (atom [0 0]))
+(def point-update-channel
+  (let [channel (chan)]
+    (add-watch point :_
+               (fn [_ _ _ new-state]
+                 (a/put! channel new-state)))
+    channel))


### PR DESCRIPTION
Shared state belongs in `rad.state`, since Clojure can not do circular dependencies.

Fixes #39.
