### PR TITLE
Add keybindings for deletion commands

### DIFF
--- a/src/rad/buffer.clj
+++ b/src/rad/buffer.clj
@@ -9,7 +9,9 @@
   (try
     (str (subs line 0 point-x) (subs line (inc point-x)))
     (catch Exception e
-      (delete-char-in-line line (dec (count line))))))
+      (if (zero? (count line))
+        line
+        (delete-char-in-line line (dec (count line)))))))
 
 (defn delete-char-at-point
   "Returns buffer without the char at point"
@@ -37,8 +39,18 @@
 (defn delete-char-backwards!
   "What your backspace key does"
   ([] (delete-char-backwards! @rad.state/point))
-  ([point] (swap! rad.state/current-buffer
-                  #(delete-char-backwards-from-point % point))))
+  ([point] (do (swap! rad.state/current-buffer
+                      #(delete-char-backwards-from-point % point))
+               (rad.point/move-point-backwards!))))
+
+(defn delete-line [buffer line-nr]
+  (try (into (subvec buffer 0 line-nr)
+             (subvec buffer (inc line-nr)))
+       (catch Exception e buffer)))
+
+(defn delete-line!
+  ([] (delete-line! @rad.state/point))
+  ([point] (swap! rad.state/current-buffer delete-line (second point))))
 
 (defn insert-char-in-line
   "Returns a string with `char' inserted at `point-y'"

--- a/src/rad/mode.clj
+++ b/src/rad/mode.clj
@@ -17,8 +17,7 @@
   [input]
   (if (keyword? input)
     (condp = input
-      :back_space (do (rad.buffer/delete-char-backwards! @rad.state/point)
-                      (rad.point/move-point-backwards! 1))
+      :back_space (rad.buffer/delete-char-backwards! @rad.state/point)
       :tab (change-mode-to! :command)
       :enter (do (rad.buffer/insert-new-line-below-point! @rad.state/point)
                  (rad.point/move-point-to-beginning-of-line!)

--- a/standard-packages/deletion_commands.clj
+++ b/standard-packages/deletion_commands.clj
@@ -1,0 +1,4 @@
+(ns deletion-commands
+  "Adds commands for deleting lines, characters etc"
+  {:command-map '{\d {\d (fn [] (rad.buffer/delete-line! @rad.state/point))
+                      \h (fn [] (rad.buffer/delete-char-backwards! @rad.state/point))}}})

--- a/test/rad/buffer_test.clj
+++ b/test/rad/buffer_test.clj
@@ -17,7 +17,9 @@
     (is (= ["ra"]
            (delete-char-at-point ["rad"] [1337 0])))
     (is (= ["rad"]
-           (delete-char-at-point ["rad"] [0 1337]))))
+           (delete-char-at-point ["rad"] [0 1337])))
+    (is (= ["" "hack"]
+           (delete-char-at-point ["" "hack"] [8 0]))))
 
   (testing "deleting a char backwards"
     (is (= ["Rd"]
@@ -39,6 +41,12 @@
              ["" "" "just some random" "" "stuff" "" "" "" "" "" ""]
              [588 8]
              "o"))))
+
+  (testing "Deleting a line"
+    (is (= ["Rad" "hack"]
+           (delete-line ["Rad" "loves" "hack"] 1)))
+    (is (= ["Rad" "loves" "hack"]
+           (delete-line ["Rad" "loves" "hack"] 999))))
 
   (testing "inserting a char in a line"
     (is (= "rad"


### PR DESCRIPTION
Add a standard package for text deletion commands
## new keybindings

``` clojure
'{\d {\d (fn [] (rad.buffer/delete-line! @rad.state/point))
      \h (fn [] (rad.buffer/delete-char-backwards! @rad.state/point))}}
```
